### PR TITLE
Added intial input in execution context

### DIFF
--- a/water/context.py
+++ b/water/context.py
@@ -39,6 +39,7 @@ class ExecutionContext:
         self.step_number = step_number
         self.attempt_number = attempt_number
         self.flow_metadata = flow_metadata or {}
+        self.initial_input = None
         
         # Timing information
         self.execution_start_time = datetime.utcnow()

--- a/water/execution_engine.py
+++ b/water/execution_engine.py
@@ -57,6 +57,7 @@ class ExecutionEngine:
             flow_id=flow_id,
             flow_metadata=flow_metadata or {}
         )
+        context.initial_input = input_data
         
         data: OutputData = input_data
         


### PR DESCRIPTION
- Modified `ExecutionEngine.run()` to store the original input in `context.initial_input`
- Ensures every task in the flow has consistent access to the original input data via the execution context
